### PR TITLE
fix format string

### DIFF
--- a/GPipe-Test/src/Main.hs
+++ b/GPipe-Test/src/Main.hs
@@ -24,7 +24,7 @@ main =
 
     -- Spew scroll info
     void . GLFW.setScrollCallback win . pure $
-        \dx dy -> printf "scroll dx%v dy%v on %v\n" dx dy
+        printf "scroll dx: %v dy: %v\n"
 
     -- Make a Render action that returns a PrimitiveArray for the cube
     let makePrimitives = do


### PR DESCRIPTION
There was an extraneous parameter which resulted in a call to error
instead of printing scrolling information.